### PR TITLE
:describe and :it can't handle double-quoted strings

### DIFF
--- a/autoload/vspec.vim
+++ b/autoload/vspec.vim
@@ -428,7 +428,7 @@ function! s:translate_script(slines)  "{{{2
   let stack = []
 
   for sline in a:slines
-    let tokens = matchlist(sline, '^\s*describe\s*\(''.*''\)\s*$')
+    let tokens = matchlist(sline, '^\s*describe\s*\(\(["'']\).*\2\)\s*$')
     if !empty(tokens)
       call insert(stack, 'describe', 0)
       call extend(rlines, [
@@ -438,7 +438,7 @@ function! s:translate_script(slines)  "{{{2
       continue
     endif
 
-    let tokens = matchlist(sline, '^\s*it\s*\(''.*''\)\s*$')
+    let tokens = matchlist(sline, '^\s*it\s*\(\(["'']\).*\2\)\s*$')
     if !empty(tokens)
       call insert(stack, 'it', 0)
       call extend(rlines, [


### PR DESCRIPTION
Currently the single quotes are hard-coded. `:describe` and `:it` only accept single-quoted strings, not any Vim string. So I think at the least these statements in the documentation should be changed:

```
{subject} is a string to describe the subject of the examples
{example} is a string to describe the example
```

Personally, I think double-quoted strings should be allowed. Some users might need, for example, a Unicode escape sequence or a tab character.

I have attached a patch.

I realize that this might make compiling less robust. Especially for `:it`, where the `{subject}` is used as a function name, it might be dangerous to allow escape sequences. The decision is up to you.
