### PR TITLE
Fix vspec runtimepath handling (issue #16)

### DIFF
--- a/bin/vspec
+++ b/bin/vspec
@@ -40,8 +40,10 @@ unset args[$((${#args[@]}- 1))]  # Now holds all {non-standard-runtimepath}s.
 cat <<END >"$driver_script"
   function s:main()
     let standard_paths = split(&runtimepath, ',')[1:-2]
-    let non_standard_paths = reverse(['$(echo "${args[@]}" |
-                                         sed "s/  */', '/g")'])
+    let non_standard_paths = reverse([$(for a in "${args[@]}"
+                                        do
+                                          printf "'%s'," "$a"
+                                        done)])
     let all_paths = copy(standard_paths)
     for i in non_standard_paths
       let all_paths = [i] + all_paths + [i . '/after']


### PR DESCRIPTION
- Fix problem when no {non-standard-runtimepath} given
- Fix handling of path names with spaces in them
