### PR TITLE
Fix carriage return escape in bin/vspec

### DIFF
--- a/bin/vspec
+++ b/bin/vspec
@@ -56,7 +56,7 @@ cat <<END >"$driver_script"
   call s:main()
 END
 
-vim -u NONE -i NONE -N -e -s -S "$driver_script" 2>&1 | sed 's/\r$//'
+vim -u NONE -i NONE -N -e -s -S "$driver_script" 2>&1 | sed $'s/\r$//'
 
 
 


### PR DESCRIPTION
The sed filter `sed 's/\r$//'` in `bin/vspec` has no effect on Mac OS X 10.9.

This is because the `\r` escape is not understood by the BSD sed on OS X. An easy fix is to pass a real carriage return character to sed.
