### PR TITLE
bin/vspec: use "--" to separate arguments

### DIFF
--- a/bin/vspec
+++ b/bin/vspec
@@ -28,7 +28,7 @@ if [[ $# != 0 && "${args[$#-1]%%*.t}" == '' ]]
 then
   "${args[$#-1]}"
 else
-  "${VSPEC_VIM:-vim}" -u NONE -i NONE -N -n -e -s --cmd "source $0-bootstrap.vim" "$@" 2>&1 |
+  "${VSPEC_VIM:-vim}" -u NONE -i NONE -N -n -e -s --cmd "source $0-bootstrap.vim" -- "$@" 2>&1 |
     sed $'/^\r\+$/d;s/\r\+$//;1{/^$/d;}'
 fi
 

--- a/t/environment-variable.t
+++ b/t/environment-variable.t
@@ -3,7 +3,7 @@
 export VSPEC_VIM=./t/echo
 
 ./t/check-vspec-result t/environment-variable.t.input <(cat <<'END'
-Echo: -u NONE -i NONE -N -n -e -s --cmd source ./bin/vspec-bootstrap.vim t/environment-variable.t.input
+Echo: -u NONE -i NONE -N -n -e -s --cmd source ./bin/vspec-bootstrap.vim -- t/environment-variable.t.input
 END
 )
 


### PR DESCRIPTION
This is required for "--help"/"-h" being passed through to vim-vspec,
and not being handled by Vim already.