### PR TITLE
Specify a test to be run.

### DIFF
--- a/autoload/vspec.vim
+++ b/autoload/vspec.vim
@@ -276,13 +276,14 @@ endfunction
 
 
 
-function! vspec#test(specfile_path)  "{{{2
+function! vspec#test(specfile_path, ...)  "{{{2
   let compiled_specfile_path = tempname()
+  let test_func = get(a:, 1, '')
   call s:compile_specfile(a:specfile_path, compiled_specfile_path)
 
   try
     execute 'source' compiled_specfile_path
-    call s:run_suites(s:all_suites)
+    call s:run_suites(s:all_suites, test_func)
   catch
     echo '#' repeat('-', 77)
     echo '#' s:simplify_call_stack(v:throwpoint, expand('<sfile>'), 'unknown')
@@ -297,10 +298,13 @@ function! vspec#test(specfile_path)  "{{{2
   call delete(compiled_specfile_path)
 endfunction
 
-function! s:run_suites(all_suites)
+function! s:run_suites(all_suites, test_func)
   let total_count_of_examples = 0
   for suite in a:all_suites
     for example_index in range(len(suite.example_list))
+      if !empty(a:test_func) && suite.example_list[example_index] != a:test_func
+        continue
+      end
       let total_count_of_examples += 1
       let example = suite.example_list[example_index]
       call suite.run_before_blocks()

--- a/bin/vspec-bootstrap.vim
+++ b/bin/vspec-bootstrap.vim
@@ -8,6 +8,12 @@ function! s:bootstrap(vspec_path)
     qall!
   endif
 
+  let test_func = ''
+  if args[-2] == '--grep' 
+    let test_func = args[-1]
+    let args = args[0:-3]
+  endif
+
   let test_script = args[-1]
   let standard_paths = split(&runtimepath, ',')[1:-2]
   let dependency_paths =
@@ -22,7 +28,7 @@ function! s:bootstrap(vspec_path)
   \ + map(reverse(copy(dependency_paths)), 'v:val . "/after"')
   let &runtimepath = join(all_paths, ',')
 
-  1 verbose call vspec#test(test_script)
+  1 verbose call vspec#test(test_script, test_func)
   qall!
 endfunction
 call s:bootstrap(expand('<sfile>:p:h:h'))

--- a/t/check-vspec-result
+++ b/t/check-vspec-result
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 dep_dirs=()
+test_func=''
 while [[ $# -ge 1 ]]
 do
   case "$1" in
@@ -9,13 +10,22 @@ do
       dep_dirs+=("$2")
       shift 2
       ;;
+    --grep)
+      test_func="$2"
+      shift 2
+      ;;
     *)
       break
       ;;
   esac
 done
 
-diff="$(diff --unified "$2" <(./bin/vspec "${dep_dirs[@]}" "$1"))"
+if [ -z "$test_func" ]; then
+  diff="$(diff --unified "$2" <(./bin/vspec "${dep_dirs[@]}" "$1"))"
+else
+  diff="$(diff --unified "$2" <(./bin/vspec "${dep_dirs[@]}" "$1" '--grep' "$test_func"))"
+fi
+
 if [ $? = 0 ]
 then
   echo 'ok 1'

--- a/t/specify-test-spec.t
+++ b/t/specify-test-spec.t
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+./t/check-vspec-result --grep "specified to be run test" <(cat <<'END'
+describe 'run single test'
+  let g:count = 1
+
+  it 'count should be 1'
+    Expect g:count == 1
+    let g:count += 1
+  end
+  it 'count should be 2'
+    Expect g:count == 2
+  end
+  it 'specified to be run test'
+    Expect g:count == 1
+  end
+end
+) <(cat <<'END'
+ok 1 - run single test specified to be run test
+1..1
+END
+)
+
+# vim: filetype=sh


### PR DESCRIPTION
Hi, after days. I finally make it, Use TDD way do need specify a test to be run. I wish this pr would be merged.
I write a test that following the t test. But I really can't figure out how to let vim-flavor support this feature.
usage:
```vim
./bin/vspec ./t/some-test_spec.vim --grep "test to be run"
```
If the code is not elegant, kana you can rewrite. TDDer do need this feature ,