### PR TITLE
Replace #!/bin/bash with #!/usr/bin/env bash

### DIFF
--- a/bin/prove-vspec
+++ b/bin/prove-vspec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bin/prove-vspec - Utility to run many tests on Vim script at once
 # Version: 1.9.2
 # Copyright (C) 2009-2021 Kana Natsuno <https://whileimautomaton.net/>

--- a/bin/vspec
+++ b/bin/vspec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bin/vspec - Driver script to test Vim script
 # Version: 1.9.2
 # Copyright (C) 2009-2021 Kana Natsuno <https://whileimautomaton.net/>

--- a/t/boolean-matcher-feailure-message.t
+++ b/t/boolean-matcher-feailure-message.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'to_be_true'

--- a/t/check-vspec-result
+++ b/t/check-vspec-result
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dep_dirs=()
 while [[ $# -ge 1 ]]

--- a/t/custom-failure-message.t
+++ b/t/custom-failure-message.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 let s:to_be_empty = {}

--- a/t/debug-print.t
+++ b/t/debug-print.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 function! InnerFunction(foo)

--- a/t/double-quoted-strings.t
+++ b/t/double-quoted-strings.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe "\<Char-0x3a>describe command"

--- a/t/echo
+++ b/t/echo
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Echo: $@"

--- a/t/environment-variable.t
+++ b/t/environment-variable.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export VSPEC_VIM=./t/echo
 

--- a/t/error-in-describe.t
+++ b/t/error-in-describe.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'Suite 1'

--- a/t/error-in-expect-evaluation.t
+++ b/t/error-in-expect-evaluation.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'Suite 1'

--- a/t/error-in-expect-parsing.t
+++ b/t/error-in-expect-parsing.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'Suite 1'

--- a/t/error-in-it.t
+++ b/t/error-in-it.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'Suite 1'

--- a/t/error-in-source.t
+++ b/t/error-in-source.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'Suite 1'

--- a/t/error-with-multiline-message.t
+++ b/t/error-with-multiline-message.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'vspec'

--- a/t/exception-matcher-failure-messages.t
+++ b/t/exception-matcher-failure-messages.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 function! Fail(s)

--- a/t/failure-messages-with-special-characters.t
+++ b/t/failure-messages-with-special-characters.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'vspec'

--- a/t/funny-it-messages.t
+++ b/t/funny-it-messages.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe ':it'

--- a/t/lib/echos
+++ b/t/lib/echos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo 'stdout'
 echo 'stderr' >&2

--- a/t/nested-describe-subjects.t
+++ b/t/nested-describe-subjects.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe 'outer :describe'

--- a/t/paths-with-spaces.t
+++ b/t/paths-with-spaces.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result -d 'foo bar' <(cat <<'END'
 describe './bin/vspec'

--- a/t/redraw.t
+++ b/t/redraw.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe ':redraw'

--- a/t/skip.t
+++ b/t/skip.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe ':SKIP'

--- a/t/throwpoint-representation.t
+++ b/t/throwpoint-representation.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 function Foo()

--- a/t/todo.t
+++ b/t/todo.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result <(cat <<'END'
 describe ':TODO'

--- a/t/vspec-path-never-duplicated.t
+++ b/t/vspec-path-never-duplicated.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./t/check-vspec-result -d "$PWD" -d "$PWD" -d "$PWD" <(cat <<'END'
 describe './bin/vspec'


### PR DESCRIPTION
`#!/bin/bash` is not platform independent (e.g. the scripts fail on NixOS, because bash is in /nix/store/<*>-bash...)
Specifying `#!/user/bin/env bash` instead uses the $PATH to look for bash.